### PR TITLE
Add modman support for Mandrill and fix some dependency issues

### DIFF
--- a/app/code/community/Ebizmarts/Autoresponder/etc/config.xml
+++ b/app/code/community/Ebizmarts/Autoresponder/etc/config.xml
@@ -155,6 +155,14 @@
                     </ebizmarts_autoresponder_save_config>
                 </observers>
             </admin_system_config_changed_section_ebizmarts_autoresponder>
+            <admin_system_config_changed_section_mandrill>
+                <observers>
+                    <mandrill_save_config>
+                        <class>ebizmarts_autoresponder/eventObserver</class>
+                        <method>saveConfig</method>
+                    </mandrill_save_config>
+                </observers>
+            </admin_system_config_changed_section_mandrill>
         </events>
     </adminhtml>
     <frontend>

--- a/app/code/community/Ebizmarts/Mandrill/etc/adminhtml.xml
+++ b/app/code/community/Ebizmarts/Mandrill/etc/adminhtml.xml
@@ -18,6 +18,15 @@
             	</email_template>
             </children>
         </system>
+        <newsletter>
+            <children>
+                <ebizmarts_mandrill>
+                    <title>Mandrill Settings</title>
+                    <sort_order>999</sort_order>
+                    <action>adminhtml/system_config/edit/section/mandrill</action>
+                </ebizmarts_mandrill>
+            </children>
+        </newsletter>
     </menu>
 	<acl>
 	    <resources>

--- a/app/code/community/Ebizmarts/Mandrill/etc/config.xml
+++ b/app/code/community/Ebizmarts/Mandrill/etc/config.xml
@@ -66,16 +66,6 @@
                 </Ebizmarts_Mandrill>
             </modules>
         </translate>
-        <events>
-            <admin_system_config_changed_section_mandrill>
-                <observers>
-                    <mandrill_save_config>
-                        <class>ebizmarts_autoresponder/eventObserver</class>
-                        <method>saveConfig</method>
-                    </mandrill_save_config>
-                </observers>
-            </admin_system_config_changed_section_mandrill>
-        </events>
     </adminhtml>
     <default>
     	<mandrill>

--- a/modman
+++ b/modman
@@ -1,0 +1,5 @@
+app/etc/modules/Ebizmarts_Mandrill.xml
+app/code/community/Ebizmarts/Mandrill
+lib/Mandrill
+app/design/adminhtml/default/default/layout/mandrill.xml
+app/design/adminhtml/default/default/template/mandrill


### PR DESCRIPTION
Move the autoresponder observer from Mandrill module to
Autoresponder module to avoid having a dependency from
Mandrill to Autoresponder

Add top nav menu to get to Mandrill settings from Newsletter
menu.  This is probably just a good idea in general, but specifically
when only installing the Mandrill module, the "monkey" tab
which it uses for it's config isn't available.

Create modman file for Mandrill module
