### PR TITLE
Added checks to prevent reminding for products that aren't available anymore

### DIFF
--- a/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
+++ b/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
@@ -140,9 +140,9 @@ class Ebizmarts_AbandonedCart_Model_Cron
                 foreach($quote->getAllVisibleItems() as $item) {
                     $removeFromQuote = false;
                     $product = Mage::getModel('catalog/product')->load($item->getProductId());
-                    if(!$product || $product->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED)
+                    if(!$product->getId() || $product->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED)
                     {
-                        Mage::log('AbandonedCart; ' . $product->getSku() .' is no longer iresent or enabled; remove from quote ' . $quote->getId() . ' for email',null,'Ebizmarts_AbandonedCart.log');
+                        Mage::log('AbandonedCart; ' . $product->getSku() .' is no longer present or enabled; remove from quote ' . $quote->getId() . ' for email',null,'Ebizmarts_AbandonedCart.log');
                         $removeFromQuote = true;
                     }
                     $stock = $product->getStockItem();


### PR DESCRIPTION
The AbndonedCart extension doesn't check whether a product that will be sent in an Abandoned Cart email is still available. 

This piece of code checks whether the product still exists, is enabled and has stock available (if stock is managed). If any of these 3 do not comply, the product is removed from the quote. 

Finally, we check whether there are still products left in the quote and if not, skip sending the email altogether after setting data to skip this quote in the future as well.
