### PR TITLE
Change how DOP is formatted in mergeVars() to match MailChimp's date field format

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
@@ -471,7 +471,7 @@ class Ebizmarts_MageMonkey_Helper_Data extends Mage_Core_Helper_Abstract
                             ->setPageSize(1)
                         	->getFirstItem();
 	                    if ( $last_order->getId() ){
-	                    	$merge_vars[$key] = Mage::helper('core')->formatDate($last_order->getCreatedAt());
+	                    	$merge_vars[$key] = date('m/d/Y', strtotime($last_order->getCreatedAt()));
 	                    }
 
 						break;


### PR DESCRIPTION
### Situation

DOP date (date of purchase) could be sent in a wrong format to the MailChimp List when subscription is synced.
### Problem

A User reported that using a different date format than "mm/dd/yyyy", this value will be sent in a wrong way.
### Possible solution - How should it be?

Change how MageMonkey parses this date and forcing it to be "mm/dd/yyyy" matching MailChimp Date field format.
