### PR TITLE
remove srand calls

### DIFF
--- a/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
+++ b/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
@@ -134,7 +134,6 @@ class Ebizmarts_AbandonedCart_Model_Cron
             }
             //
             //$url = Mage::getBaseUrl('web').'ebizmarts_abandonedcart/abandoned/loadquote?id='.$quote->getEntityId();
-            srand((double)microtime()*1000000);
             $token = md5(rand(0,9999999));
             $url = Mage::getModel('core/url')->setStore($store)->getUrl('',array('_nosid'=>true)).'ebizmarts_abandonedcart/abandoned/loadquote?id='.$quote->getEntityId().'&token='.$token;
 

--- a/app/code/community/Ebizmarts/Autoresponder/Model/Cron.php
+++ b/app/code/community/Ebizmarts/Autoresponder/Model/Cron.php
@@ -286,7 +286,6 @@ class Ebizmarts_Autoresponder_Model_Cron
             $email = $order->getCustomerEmail();
             if($this->_isSubscribed($email,'review',$storeId)) {
                 if(Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::REVIEW_HAS_COUPON,$storeId)) {
-                    srand((double)microtime()*1000000);
                     $token = md5(rand(0,9999999));
                     $review = Mage::getModel('ebizmarts_autoresponder/review');
                     $review->setCustomerId($order->getCustomerId())


### PR DESCRIPTION
http://php.net/manual/en/function.srand.php
"Note: As of PHP 4.2.0, there is no need to seed the random number
generator with srand() or mt_srand() as this is now done automatically."

also: the automatic solution in php is more random and less predictable then microtime

and, I dont think you need to initialize the random number generator for every iteration of foreach, it does not get more random
