### PR TITLE
$configscope in config() helper method, validate not to be an array

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
@@ -197,7 +197,7 @@ class Ebizmarts_MageMonkey_Helper_Data extends Mage_Core_Helper_Abstract
 		$store = is_null($store) ? Mage::app()->getStore() : $store;
 
 		$configscope = Mage::app()->getRequest()->getParam('store');
-		if( $configscope && ($configscope !== 'undefined') ){
+		if( $configscope && ($configscope !== 'undefined') && !is_array($configscope) ){
 			$store = $configscope;
 		}
 


### PR DESCRIPTION
### Situation - How did you get there?

Raised by a User from the Community
### Problem - What went wrong?

Infortis generates these CSS files by creating a Core/Template Block and writing output from toHTML() call to each CSS file. However, by generating the Block it triggers Magento's _core_block_abstract_prepare_layout_before_ event.

MageMonkey has an Observer for this event that is designed to only add a Mass Action option on the Sales Grid.
### Possible solution - How should it be?

Add a validation to config() method

``` php
    if( $configscope && ($configscope !== 'undefined') && !is_array($configscope) ){
        $store = $configscope;
    }
```
