### PR TITLE
Fixed Webhook URL in multi-store environment

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/controllers/WebhookController.php
+++ b/app/code/community/Ebizmarts/MageMonkey/controllers/WebhookController.php
@@ -28,10 +28,13 @@ class Ebizmarts_MageMonkey_WebhookController extends Mage_Core_Controller_Front_
             	->sendResponse();
         	return $this;
 		}
-		
+
 		Mage::helper('monkey')->log( print_r($this->getRequest()->getPost(), true) );
 
-		Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+		if (Mage::getStoreConfig('web/url/use_store') != '1')
+		{
+			Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+		}
 
 		$data  = $this->getRequest()->getPost('data');
 		$myKey = Mage::helper('monkey')->getWebhooksKey(null, $data['list_id']);

--- a/app/code/community/Ebizmarts/MageMonkey/controllers/WebhookController.php
+++ b/app/code/community/Ebizmarts/MageMonkey/controllers/WebhookController.php
@@ -12,46 +12,45 @@
 class Ebizmarts_MageMonkey_WebhookController extends Mage_Core_Controller_Front_Action
 {
 
-	/**
-	 * Entry point for all webhook operations
-	 */
-	public function indexAction()
-	{
+    /**
+     * Entry point for all webhook operations
+     */
+    public function indexAction()
+    {
+        $requestKey = $this->getRequest()->getParam('wkey');
 
-		$requestKey = $this->getRequest()->getParam('wkey');
+        // Checking if "wkey" para is present on request, we cannot check for !isPost()
+        // because Mailchimp pings the URL (GET request) to validate webhook
+        if (!$requestKey)
+        {
+            $this->getResponse()
+                ->setHeader('HTTP/1.1', '403 Forbidden')
+                ->sendResponse();
+            return $this;
+        }
 
-		//Checking if "wkey" para is present on request, we cannot check for !isPost()
-		//because Mailchimp pings the URL (GET request) to validate webhook
-		if( !$requestKey ){
-			$this->getResponse()
-            	->setHeader('HTTP/1.1', '403 Forbidden')
-            	->sendResponse();
-        	return $this;
-		}
+        Mage::helper('monkey')->log( print_r($this->getRequest()->getPost(), true) );
 
-		Mage::helper('monkey')->log( print_r($this->getRequest()->getPost(), true) );
+        if (Mage::getStoreConfig('web/url/use_store') != '1')
+        {
+            Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+        }
 
-		if (Mage::getStoreConfig('web/url/use_store') != '1')
-		{
-			Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
-		}
+        $data  = $this->getRequest()->getPost('data');
+        $myKey = Mage::helper('monkey')->getWebhooksKey(null, $data['list_id']);
 
-		$data  = $this->getRequest()->getPost('data');
-		$myKey = Mage::helper('monkey')->getWebhooksKey(null, $data['list_id']);
-
-		//Validate "wkey" GET parameter
-		if ($this->getRequest()->getPost('type')) {
-		        Mage::getModel('monkey/monkey')->processWebhookData($this->getRequest()->getPost());
-		} else {
-			if($myKey != $requestKey) {
-		               Mage::helper('monkey')->log($this->__('Webhook Key invalid! Key Request: %s - My Key: %s', $requestKey, $myKey));
-			}
-
-                        Mage::helper('monkey')->log($this->__('Webhook call ended'));
-                }
-
-
-
-	}
-
+        // Validate "wkey" GET parameter
+        if ($this->getRequest()->getPost('type'))
+        {
+            Mage::getModel('monkey/monkey')->processWebhookData($this->getRequest()->getPost());
+        }
+        else
+        {
+            if($myKey != $requestKey)
+            {
+                Mage::helper('monkey')->log($this->__('Webhook Key invalid! Key Request: %s - My Key: %s', $requestKey, $myKey));
+            }
+            Mage::helper('monkey')->log($this->__('Webhook call ended'));
+        }
+    }
 }

--- a/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
+++ b/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
@@ -10,7 +10,7 @@
 <config>
     <modules>
         <Ebizmarts_MageMonkey>
-             <version>1.1.21</version>
+             <version>1.1.22</version>
         </Ebizmarts_MageMonkey>
     </modules>
     <global>

--- a/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
+++ b/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
@@ -14,7 +14,7 @@
         </Ebizmarts_MageMonkey>
     </modules>
     <global>
-    	<events>
+        <events>
             <newsletter_subscriber_save_before>
                 <observers>
                     <monkey_subscribe_observer>
@@ -39,7 +39,7 @@
                     </monkey_update_customer>
                 </observers>
             </customer_save_after>
-    	</events>
+        </events>
         <models>
             <monkey>
                 <class>Ebizmarts_MageMonkey_Model</class>
@@ -113,47 +113,47 @@
             </updates>
         </layout>
         <events>
-			<controller_action_predispatch_onestepcheckout_index_index>
-	           	<observers>
-	               <monkey_subscribe_checkout>
-	                   <class>monkey/observer</class>
-	                   <method>registerCheckoutSubscribe</method>
-	               </monkey_subscribe_checkout>
-	         	</observers>
-	        </controller_action_predispatch_onestepcheckout_index_index>
-			<controller_action_postdispatch_checkout_onepage_saveOrder>
-	           	<observers>
-	               <monkey_subscribe_checkout>
-	                   <class>monkey/observer</class>
-	                   <method>registerCheckoutSubscribe</method>
-	               </monkey_subscribe_checkout>
-	         	</observers>
-	        </controller_action_postdispatch_checkout_onepage_saveOrder>
-	        <checkout_onepage_controller_success_action>
-	           	<observers>
-	               <monkey_subscribe_checkoutsuccess>
-	                   <class>monkey/observer</class>
-	                   <method>registerCheckoutSuccess</method>
-	               </monkey_subscribe_checkoutsuccess>
-	         	</observers>
-	        </checkout_onepage_controller_success_action>
-	        <controller_action_postdispatch>
-	           	<observers>
-	               <monkey_ecomm_tracking_cookie>
-	                   <class>monkey/ecommerce360</class>
-	                   <method>saveCookie</method>
-	               </monkey_ecomm_tracking_cookie>
-	         	</observers>
-	        </controller_action_postdispatch>
-			<sales_order_place_after>
-			  <observers>
-			      <monkey_ecomm_tracking_sendorder>
-			          <class>monkey/ecommerce360</class>
-			          <method>run</method>
-			      </monkey_ecomm_tracking_sendorder>
-			  </observers>
-			</sales_order_place_after>
-      	</events>
+            <controller_action_predispatch_onestepcheckout_index_index>
+                   <observers>
+                   <monkey_subscribe_checkout>
+                       <class>monkey/observer</class>
+                       <method>registerCheckoutSubscribe</method>
+                   </monkey_subscribe_checkout>
+                 </observers>
+            </controller_action_predispatch_onestepcheckout_index_index>
+            <controller_action_postdispatch_checkout_onepage_saveOrder>
+                   <observers>
+                   <monkey_subscribe_checkout>
+                       <class>monkey/observer</class>
+                       <method>registerCheckoutSubscribe</method>
+                   </monkey_subscribe_checkout>
+                 </observers>
+            </controller_action_postdispatch_checkout_onepage_saveOrder>
+            <checkout_onepage_controller_success_action>
+                   <observers>
+                   <monkey_subscribe_checkoutsuccess>
+                       <class>monkey/observer</class>
+                       <method>registerCheckoutSuccess</method>
+                   </monkey_subscribe_checkoutsuccess>
+                 </observers>
+            </checkout_onepage_controller_success_action>
+            <controller_action_postdispatch>
+                   <observers>
+                   <monkey_ecomm_tracking_cookie>
+                       <class>monkey/ecommerce360</class>
+                       <method>saveCookie</method>
+                   </monkey_ecomm_tracking_cookie>
+                 </observers>
+            </controller_action_postdispatch>
+            <sales_order_place_after>
+              <observers>
+                  <monkey_ecomm_tracking_sendorder>
+                      <class>monkey/ecommerce360</class>
+                      <method>run</method>
+                  </monkey_ecomm_tracking_sendorder>
+              </observers>
+            </sales_order_place_after>
+          </events>
     </frontend>
     <admin>
         <routers>
@@ -167,13 +167,13 @@
         </routers>
     </admin>
     <adminhtml>
-    	<layout>
-	        <updates>
-	            <magemonkey>
-	                <file>magemonkey.xml</file>
-	            </magemonkey>
-	        </updates>
-    	</layout>
+        <layout>
+            <updates>
+                <magemonkey>
+                    <file>magemonkey.xml</file>
+                </magemonkey>
+            </updates>
+        </layout>
         <translate>
             <modules>
                 <Ebizmarts_MageMonkey>
@@ -220,27 +220,27 @@
         </events>
     </adminhtml>
     <default>
-    	<monkey>
-	    	<custom_groupings>
-				<segment_grouping_name><![CDATA[MAGE_CUSTOMER_SEGMENTS]]></segment_grouping_name>
-			</custom_groupings>
-    		<general>
-	    		<active>0</active>
-	    		<double_optin>System->Configuration->Customers->Newsletter->Subscription Options->Need to Confirm</double_optin>
-				<ecommerce360>0</ecommerce360>
-				<showreallistname>0</showreallistname>
-				<checkout_subscribe>0</checkout_subscribe>
-				<transactional_emails>false</transactional_emails>
-				<map_fields><![CDATA[a:14:{i:0;a:2:{s:7:"magento";s:9:"firstname";s:9:"mailchimp";s:5:"FNAME";}i:1;a:2:{s:7:"magento";s:8:"lastname";s:9:"mailchimp";s:5:"LNAME";}i:2;a:2:{s:7:"magento";s:3:"dob";s:9:"mailchimp";s:3:"DOB";}i:3;a:2:{s:7:"magento";s:6:"prefix";s:9:"mailchimp";s:7:"PRENAME";}i:4;a:2:{s:7:"magento";s:15:"billing_address";s:9:"mailchimp";s:7:"BILLING";}i:5;a:2:{s:7:"magento";s:16:"shipping_address";s:9:"mailchimp";s:8:"SHIPPING";}i:6;a:2:{s:7:"magento";s:6:"gender";s:9:"mailchimp";s:6:"GENDER";}i:7;a:2:{s:7:"magento";s:8:"store_id";s:9:"mailchimp";s:7:"STOREID";}i:8;a:2:{s:7:"magento";s:10:"website_id";s:9:"mailchimp";s:7:"WEBSITE";}i:9;a:2:{s:7:"magento";s:16:"date_of_purchase";s:9:"mailchimp";s:3:"DOP";}i:10;a:2:{s:7:"magento";s:19:"ee_customer_balance";s:9:"mailchimp";s:9:"STORECRED";}i:11;a:2:{s:7:"magento";s:8:"group_id";s:9:"mailchimp";s:6:"CGROUP";}i:12;a:2:{s:7:"magento";s:9:"telephone";s:9:"mailchimp";s:9:"TELEPHONE";}i:13;a:2:{s:7:"magento";s:7:"company";s:9:"mailchimp";s:7:"COMPANY";}}]]></map_fields>
-				<cron_export>1000</cron_export>
-				<order_status>all_status</order_status>
-				<enable_log>1</enable_log>
-    		</general>
+        <monkey>
+            <custom_groupings>
+                <segment_grouping_name><![CDATA[MAGE_CUSTOMER_SEGMENTS]]></segment_grouping_name>
+            </custom_groupings>
+            <general>
+                <active>0</active>
+                <double_optin>System->Configuration->Customers->Newsletter->Subscription Options->Need to Confirm</double_optin>
+                <ecommerce360>0</ecommerce360>
+                <showreallistname>0</showreallistname>
+                <checkout_subscribe>0</checkout_subscribe>
+                <transactional_emails>false</transactional_emails>
+                <map_fields><![CDATA[a:14:{i:0;a:2:{s:7:"magento";s:9:"firstname";s:9:"mailchimp";s:5:"FNAME";}i:1;a:2:{s:7:"magento";s:8:"lastname";s:9:"mailchimp";s:5:"LNAME";}i:2;a:2:{s:7:"magento";s:3:"dob";s:9:"mailchimp";s:3:"DOB";}i:3;a:2:{s:7:"magento";s:6:"prefix";s:9:"mailchimp";s:7:"PRENAME";}i:4;a:2:{s:7:"magento";s:15:"billing_address";s:9:"mailchimp";s:7:"BILLING";}i:5;a:2:{s:7:"magento";s:16:"shipping_address";s:9:"mailchimp";s:8:"SHIPPING";}i:6;a:2:{s:7:"magento";s:6:"gender";s:9:"mailchimp";s:6:"GENDER";}i:7;a:2:{s:7:"magento";s:8:"store_id";s:9:"mailchimp";s:7:"STOREID";}i:8;a:2:{s:7:"magento";s:10:"website_id";s:9:"mailchimp";s:7:"WEBSITE";}i:9;a:2:{s:7:"magento";s:16:"date_of_purchase";s:9:"mailchimp";s:3:"DOP";}i:10;a:2:{s:7:"magento";s:19:"ee_customer_balance";s:9:"mailchimp";s:9:"STORECRED";}i:11;a:2:{s:7:"magento";s:8:"group_id";s:9:"mailchimp";s:6:"CGROUP";}i:12;a:2:{s:7:"magento";s:9:"telephone";s:9:"mailchimp";s:9:"TELEPHONE";}i:13;a:2:{s:7:"magento";s:7:"company";s:9:"mailchimp";s:7:"COMPANY";}}]]></map_fields>
+                <cron_export>1000</cron_export>
+                <order_status>all_status</order_status>
+                <enable_log>1</enable_log>
+            </general>
             <notifications>
                 <updates_url><![CDATA[http://store.ebizmarts.com/media/feeds/]]></updates_url>
                 <check_frequency>86400</check_frequency>
             </notifications>
-    	</monkey>
+        </monkey>
     </default>
     <crontab>
         <jobs>


### PR DESCRIPTION
When in multi-store environment its not unusual to add the store code to the url. Lets say you have two store views A and B with store codes `store-a` and `store-b` with store A being the default store. I want the two stores to have complete separated lists so I setup my mailchimp configuration with two api keys. The lists are pulled from the mailchimp api but when changing the default list for store B the generated webhook url looks like this:

`http://my.domain.tld/store-a/store-b/monkey/webhook/index/wkey/dd69b2df6698776bstore-b/`

`store-a` should not be there, the url returns a 404. The culprit is this line in class WebhookController:

```php
Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
```
I don't see the reason why this line needs to be there, but just in case I enclosed it in a conditional statement that only disables it when the store codes are appended to the url.

##### Bonus
Changed tabs to spaces and improved readability of controller class