### PR TITLE
Update visitedproducts.js

### DIFF
--- a/js/ebizmarts/autoresponders/visitedproducts.js
+++ b/js/ebizmarts/autoresponders/visitedproducts.js
@@ -4,7 +4,7 @@
  * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *
  */
-(function () {
+;(function () {
     function markVisited(productID) {
         new Ajax.Request('../index.php/ebizautoresponder/autoresponder/markVisitedProducts?product_id=' + productID, {
             method: 'get',


### PR DESCRIPTION
When setting the Magento JavaScript merge setting in System > Developer > JavaScript Settings > Merge JavaScript Files is set to yes the frontend gives a JavaScript error. This is because the JavaScript file preceding the visitedproducts.js isn't using an ending ; to properly end the JS file. Putting an extra ; infront of the visitedproducts.js file the issue get's fixed.

Tom
