### PR TITLE
Mandrill: Sub-account integration for multi-store

### DIFF
--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
@@ -19,7 +19,15 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
      */
     public function send($email, $name = null, array $variables = array())
     {
-        $storeId = Mage::app()->getStore()->getId();
+        //get store ID
+        if(isset($variables['store'])&& $variables['store'] instanceof Mage_Core_Model_Store){
+            $store = $variables['store'];
+            $storeId = $store->getId();
+        }
+        else{
+            $storeId = Mage::app()->getStore()->getId();
+        }
+
         if(!Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::ENABLE,$storeId)) {
            return parent::send($email, $name,$variables);
         }
@@ -71,8 +79,9 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
         $email['from_name'] = $this->getSenderName();
         $email['from_email'] = $this->getSenderEmail();
         $email['headers'] = $mail->getHeaders();
-        if(isset($variables['tags']) && count($variables['tags'])) {
-            $email ['tags'] = $variables['tags'];
+
+        if($sub_account = Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::SUBACCOUNT, $storeId)){
+            $email['subaccount'] = $sub_account;
         }
 
         if(isset($variables['tags']) && count($variables['tags'])) {

--- a/app/code/community/Ebizmarts/Mandrill/Model/System/Config.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/System/Config.php
@@ -10,5 +10,6 @@ class Ebizmarts_Mandrill_Model_System_Config
 {
     const ENABLE        = 'mandrill/general/active';
     const APIKEY        = 'mandrill/general/apikey';
+    const SUBACCOUNT    = 'mandrill/general/subaccount';
     const ENABLE_LOG    = 'mandrill/general/enable_log';
 }

--- a/app/code/community/Ebizmarts/Mandrill/etc/system.xml
+++ b/app/code/community/Ebizmarts/Mandrill/etc/system.xml
@@ -48,6 +48,18 @@
                                 <active>1</active>
                             </depends>
                         </apikey>
+                        <subaccount translate="label comment">
+                            <label>Sub Account</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>25</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Optional: subaccount]]></comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                        </subaccount>
                         <enable_log translate="label comment">
                             <label>Enable Log</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
Hello my first pull request, so don't hate me for screwing it up too much.
The purpose of this modification is to provide the user with the ability of providing a subaccount for mandrill to use. This is great for multi-store setups where the customer can just add their subaccount id into the mandrill config and it will be appended to all transactional emails of a particular store.

I also adjusted the store ID getter as that was not working correctly with out of scope multi-store sendouts (calls from observers). I also removed repeating IF block code for tags, it just repeats itself unnecessarily.

Tell me if you need me to adjust the pull request somehow.
Tested with mage v.1.9.1 (php5.5, mysql 5.6 Centos & Ubuntu), but I don't see why it wouldn't work in other versions as well.
Cheers,
Konstantin K