### PR TITLE
MageMonkey: Multi-site fix for sub groups in config

### DIFF
--- a/app/design/adminhtml/default/default/template/magemonkey/system/config/resetlocal360.phtml
+++ b/app/design/adminhtml/default/default/template/magemonkey/system/config/resetlocal360.phtml
@@ -16,7 +16,7 @@
     }
     function reloadGroups(evt) {
         var $list = $('monkey_general_list').getValue();
-        var $url = "<?php echo Mage::helper('adminhtml')->getUrl('adminhtml/config/getGroups'); ?>"+"list/"+$list;
+        var $url = "<?php echo Mage::helper('adminhtml')->getUrl('monkey/adminhtml_config/getGroups', array('store' => $this->getRequest()->getParam('store'))) ?>"+"list/"+$list;
         new Ajax.Request($url, {
             method: 'get',
             onSuccess: function (transport) {


### PR DESCRIPTION
The problem is when one has 2 stores and trying to save Customer Groups per store. After you save it does not load the customer group or that particular store. Why this happens is that the ConfigController.php (``app/code/community/Ebizmarts/MageMonkey/controllers/Adminhtml/ConfigController.php``) is trying to load the config of a particular store, however, there is no store id provided to it, see line 15 of that file.
```php
     $params = $this->getRequest()->getParams();
       ...
      if(isset($params['store'])) {
          $store = $params['store'];
```
I just passed the ``store_id`` to the controller via url. I am assuming that's what you guys wanted to do initially but forgot to.
**Before fix:**
![Before Fix](http://kiritsenko.com/wp-content/uploads/2015/02/ebizmarts-multisite-config-pre-fix.jpg)
**After fix:**
![After Fix](http://kiritsenko.com/wp-content/uploads/2015/02/ebizmarts-multisite-configpost-fix.jpg)