### PR TITLE
Update EventObserver.php

### DIFF
--- a/app/code/community/Ebizmarts/Autoresponder/Model/EventObserver.php
+++ b/app/code/community/Ebizmarts/Autoresponder/Model/EventObserver.php
@@ -237,29 +237,29 @@ class Ebizmarts_Autoresponder_Model_EventObserver
         $new_data = $observer->getEvent()->getData('data_object')->getData();
 
         $order = $observer->getEvent()->getOrder();
-
-        if ($new_data['status'] && $original_data['status'] !== $new_data['status'] && $new_data['status'] == Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_ORDER_STATUS, $storeId)) {
-            if(Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_ACTIVE, $storeId) && Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_TRIGGER, $storeId) == 1){
-                $tags           = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_MANDRILL_TAG,$storeId)."_$storeId";
-                $mailSubject    = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_SUBJECT,$storeId);
-                $senderId       = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::GENERAL_SENDER,$storeId);
-                $sender         = array('name'=>Mage::getStoreConfig("trans_email/ident_$senderId/name",$storeId), 'email'=> Mage::getStoreConfig("trans_email/ident_$senderId/email",$storeId));
-                $templateId     = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_TEMPLATE,$storeId);
-
-                //Send email
-                $translate = Mage::getSingleton('core/translate');
-                $email = $order->getCustomerEmail();
-                if(Mage::helper('ebizmarts_autoresponder')->isSubscribed($email,'neworder',$storeId)) {
-                    $name = $order->getCustomerFirstname().' '.$order->getCustomerLastname();
-                    $url = Mage::getModel('core/url')->setStore($storeId)->getUrl().'ebizautoresponder/autoresponder/unsubscribe?list=neworder&email='.$email.'&store='.$storeId;
-                    $vars = array('tags'=>array($tags),'url'=>$url);
-                    $mail = Mage::getModel('core/email_template')->setTemplateSubject($mailSubject)->sendTransactional($templateId,$sender,$email,$name,$vars,$storeId);
-                    $translate->setTranslateInLine(true);
-                    Mage::helper('ebizmarts_abandonedcart')->saveMail('new order',$email,$name,"",$storeId);
+        if (array_key_exists('status', $new_data)) {
+            if ($new_data['status'] && $original_data['status'] !== $new_data['status'] && $new_data['status'] == Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_ORDER_STATUS, $storeId)) {
+                if(Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_ACTIVE, $storeId) && Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_TRIGGER, $storeId) == 1){
+                    $tags           = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_MANDRILL_TAG,$storeId)."_$storeId";
+                    $mailSubject    = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_SUBJECT,$storeId);
+                    $senderId       = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::GENERAL_SENDER,$storeId);
+                    $sender         = array('name'=>Mage::getStoreConfig("trans_email/ident_$senderId/name",$storeId), 'email'=> Mage::getStoreConfig("trans_email/ident_$senderId/email",$storeId));
+                    $templateId     = Mage::getStoreConfig(Ebizmarts_Autoresponder_Model_Config::NEWORDER_TEMPLATE,$storeId);
+    
+                    //Send email
+                    $translate = Mage::getSingleton('core/translate');
+                    $email = $order->getCustomerEmail();
+                    if(Mage::helper('ebizmarts_autoresponder')->isSubscribed($email,'neworder',$storeId)) {
+                        $name = $order->getCustomerFirstname().' '.$order->getCustomerLastname();
+                        $url = Mage::getModel('core/url')->setStore($storeId)->getUrl().'ebizautoresponder/autoresponder/unsubscribe?list=neworder&email='.$email.'&store='.$storeId;
+                        $vars = array('tags'=>array($tags),'url'=>$url);
+                        $mail = Mage::getModel('core/email_template')->setTemplateSubject($mailSubject)->sendTransactional($templateId,$sender,$email,$name,$vars,$storeId);
+                        $translate->setTranslateInLine(true);
+                        Mage::helper('ebizmarts_abandonedcart')->saveMail('new order',$email,$name,"",$storeId);
+                    }
                 }
             }
         }
-
     }
 
 }


### PR DESCRIPTION
Fixes "Undefined index" error observed when creating new order. Issue is related to checking non existing array data.
Related error log in system.log (Magento EE 1.14.0.1, PHP 5.4.4-14): ERR (3): Notice: Undefined index: status  in /var/www/magento/app/code/community/Ebizmarts/Autoresponder/Model/EventObserver.php on line 241