### PR TITLE
remove parenthesis from observer call

### DIFF
--- a/js/ebizmarts/magemonkey/campaignCatcher.js
+++ b/js/ebizmarts/magemonkey/campaignCatcher.js
@@ -28,6 +28,6 @@
     if (document.loaded) {
         getCampaign();
     } else {
-        document.observe('dom:loaded', getCampaign());
+        document.observe('dom:loaded', getCampaign);
     }
 })();


### PR DESCRIPTION
These parenthesis cause an 'undefined handler' javascript error in the
prototype.js library if left in.