### PR TITLE
Add additional JS folders to modman

### DIFF
--- a/modman
+++ b/modman
@@ -30,6 +30,8 @@ app/design/frontend/base/default/template/ebizmarts/autoresponder       app/desi
 app/design/frontend/base/default/template/ebizmarts_abandonedcart       app/design/frontend/base/default/template/ebizmarts_abandonedcart
 app/design/frontend/base/default/template/magemonkey                    app/design/frontend/base/default/template/magemonkey
 js/ebizmarts/abandonedcart                                              js/ebizmarts/abandonedcart
+js/ebizmarts/autoresponders                                             js/ebizmarts/autoresponders
+js/ebizmarts/magemonkey                                                 js/ebizmarts/magemonkey
 skin/adminhtml/default/default/abandonedcart                            skin/adminhtml/default/default/abandonedcart
 skin/adminhtml/default/default/ebizmarts                                skin/adminhtml/default/default/ebizmarts
 skin/adminhtml/default/default/magemonkey                               skin/adminhtml/default/default/magemonkey


### PR DESCRIPTION
After deploying the extension using modman (with composer) then visiting the site on the front end resulted in a 404 for the following file: `/js/ebizmarts/autoresponders/visitedproducts.js`

Managed to trace it back to it not being in the modman file, and noticed the `/js/ebizmarts/magemonkey/` folder was missing too.