### PR TITLE
Fix group listing

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/Block/Lists.php
+++ b/app/code/community/Ebizmarts/MageMonkey/Block/Lists.php
@@ -255,7 +255,7 @@ class Ebizmarts_MageMonkey_Block_Lists extends Mage_Core_Block_Template
                     }
                 }
                 if (isset($groupings)) {
-                    array_merge($this->_setGrouping($groupings,$fieldType,$myGroups), $myGroups);
+                    $myGroups = $this->_setGrouping($groupings,$fieldType,$myGroups);
                 }
             }
         }


### PR DESCRIPTION
Make sure `$myGroups` gets a valid array, that is with the list ID as key, set to it. Resolves issue where checkboxes in group listing wasn't checked.