### PR TITLE
Replace PHP date with Magento date

### DIFF
--- a/app/code/community/Ebizmarts/Autoresponder/Helper/Data.php
+++ b/app/code/community/Ebizmarts/Autoresponder/Helper/Data.php
@@ -98,7 +98,7 @@ class Ebizmarts_Autoresponder_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function isSetTime($setTime)
     {
-        $now = date('H');
+        $now = date('H', Mage::getModel('core/date')->timestamp(time()));
         if ($now == $setTime) {
             return true;
         }


### PR DESCRIPTION
The module Ebizmarts_Autoresponder is using PHP time function to check if the current time is the right time to run a task. This causes the task to be executed in a different time if Magento is configured with a timezone different than GMT. This change is making the module use Magento time function.