### PR TITLE
Firecheckout Compatibility

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/Model/Observer.php
+++ b/app/code/community/Ebizmarts/MageMonkey/Model/Observer.php
@@ -348,7 +348,7 @@ class Ebizmarts_MageMonkey_Model_Observer
         $request = Mage::app()->getRequest();
         $isAdmin = $request->getActionName() == 'save' && $request->getControllerName() == 'customer' && $request->getModuleName() == (string)Mage::getConfig()->getNode('admin/routers/adminhtml/args/frontName');
         $customer = $observer->getEvent()->getCustomer();
-        $isCheckout = $request->getModuleName() == 'checkout' || Mage::getSingleton('core/session')->getIsOneStepCheckout();
+        $isCheckout = $request->getModuleName() == 'checkout' || $request->getModuleName() == 'firecheckout' || Mage::getSingleton('core/session')->getIsOneStepCheckout();
 //        $isConfirmNeed = FALSE;
 //        if (!Mage::helper('monkey')->isAdmin() &&
 //            (Mage::getStoreConfig(Mage_Newsletter_Model_Subscriber::XML_PATH_CONFIRMATION_FLAG, $customer->getStoreId()) == 1)

--- a/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
+++ b/app/code/community/Ebizmarts/MageMonkey/etc/config.xml
@@ -151,6 +151,14 @@
                     </monkey_subscribe_checkout>
                 </observers>
             </controller_action_postdispatch_checkout_onepage_saveOrder>
+            <controller_action_postdispatch_firecheckout_index_saveOrder>
+                <observers>
+                    <monkey_subscribe_checkout>
+                        <class>monkey/observer</class>
+                        <method>registerCheckoutSubscribe</method>
+                    </monkey_subscribe_checkout>
+                </observers>
+            </controller_action_postdispatch_firecheckout_index_saveOrder>
             <checkout_onepage_controller_success_action>
                 <observers>
                     <monkey_subscribe_checkoutsuccess>

--- a/app/design/frontend/base/default/template/magemonkey/checkout/subscribe.phtml
+++ b/app/design/frontend/base/default/template/magemonkey/checkout/subscribe.phtml
@@ -202,40 +202,42 @@ $force = $this->getForce();
 
         });
     });
-    //If force subscription or checked by default set the elements as clicked
-    <?php if($auto):?>addSubscribeToPost($('magemonkey-trigger'));
-    <?php if($this->getCanModify() && is_array($generalList['interest_groupings'])): ?>
-    <?php foreach($generalList['interest_groupings'] as $group): ?>
-    <?php foreach($group['groups'] as $g): ?>
-    <?php $idToAdd = $this->getGroupId($g, TRUE); ?>
-    <?php if($idToAdd): ?>
-    if ($(<?php Print(json_encode($idToAdd));?>)) {
-        addGroupToPost($(<?php Print(json_encode($idToAdd));?>));
-    }
-    <?php endif; ?>
-    <?php endforeach; ?>
-    <?php endforeach; ?>
-    <?php endif; ?>
-    <?php endif; ?>
-    <?php if($auto):
-        foreach($lists as $list):
-            $string = "magemonkey-trigger-".$list['id'];
-            ?>addSubscribeToPost($(<?php Print(json_encode($string)); ?>));
-    <?php if(is_array($list['interest_groupings'])): ?>
-    <?php foreach($list['interest_groupings'] as $group): ?>
-    <?php foreach($group['groups'] as $g): ?>
-    <?php $idToAdd = $this->getGroupId($g, TRUE); ?>
-    <?php if($idToAdd): ?>
-    if ($(<?php Print(json_encode($idToAdd));?>)) {
-        addGroupToPost($(<?php Print(json_encode($idToAdd));?>));
-    }
-    <?php endif; ?>
-    <?php endforeach; ?>
-    <?php endforeach; ?>
-    <?php endif; ?>
-    <?php endforeach; ?>
-    <?php endif; ?>
 
+    document.observe("dom:loaded", function() {
+        //If force subscription or checked by default set the elements as clicked
+        <?php if($auto):?>addSubscribeToPost($('magemonkey-trigger'));
+        <?php if($this->getCanModify() && is_array($generalList['interest_groupings'])): ?>
+        <?php foreach($generalList['interest_groupings'] as $group): ?>
+        <?php foreach($group['groups'] as $g): ?>
+        <?php $idToAdd = $this->getGroupId($g, TRUE); ?>
+        <?php if($idToAdd): ?>
+        if ($(<?php Print(json_encode($idToAdd));?>)) {
+            addGroupToPost($(<?php Print(json_encode($idToAdd));?>));
+        }
+        <?php endif; ?>
+        <?php endforeach; ?>
+        <?php endforeach; ?>
+        <?php endif; ?>
+        <?php endif; ?>
+        <?php if($auto):
+            foreach($lists as $list):
+                $string = "magemonkey-trigger-".$list['id'];
+                ?>addSubscribeToPost($(<?php Print(json_encode($string)); ?>));
+        <?php if(is_array($list['interest_groupings'])): ?>
+        <?php foreach($list['interest_groupings'] as $group): ?>
+        <?php foreach($group['groups'] as $g): ?>
+        <?php $idToAdd = $this->getGroupId($g, TRUE); ?>
+        <?php if($idToAdd): ?>
+        if ($(<?php Print(json_encode($idToAdd));?>)) {
+            addGroupToPost($(<?php Print(json_encode($idToAdd));?>));
+        }
+        <?php endif; ?>
+        <?php endforeach; ?>
+        <?php endforeach; ?>
+        <?php endif; ?>
+        <?php endforeach; ?>
+        <?php endif; ?>
+    });
 
     //    if( $$('div#checkout-step-review div.monkey-multisubscribe').length ){
     //


### PR DESCRIPTION
We had some issues when using the magemonkey extension in combination with firecheckout (widespread one page checkout extension). I fixed them for our install and would like to share our fix for others. 

 * As it turns out, the script handling pre-selection of the newsletter checkbox is executed _before_ the  required elements, e.g., _$('magemonkey-trigger')_, are added to the dom in this case. This results in the newsletter checkbox being visually selected, however, the actual selection is not added to the post request (unless the user clicks a few times on the checkbox). Delaying it to the _"dom:loaded"_ event solves the problem for integration with the firecheckout extension and I don't see any harm done to the "normal" checkout page.
 * As firecheckout uses a different controller than onepagecheckout and the normal method, the _Observer->registerCheckoutSubscribe($observer)_ method is never called. This results in _Mage::getSingleton('core/session')->getMonkeyPost();_ returning a null value, which in turn makes the _Ebizmarts_MageMonkey_Helper_Data_ class think it should subscribe the customer anyway (even if de-selected on the frontend) in the _listsSubscription($object, $db)_ method (line 902 ff.). A rather nasty to find bug, which results in the customer receiving "annoying" double opt in mails. The fix is to just add the firecheckout controller event to the config, also rather unintrusive for other configurations, but very helpful for firecheckout users.