### PR TITLE
No Confirmation When Subscription Is Forced

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
+++ b/app/code/community/Ebizmarts/MageMonkey/Helper/Data.php
@@ -897,7 +897,7 @@ class Ebizmarts_MageMonkey_Helper_Data extends Mage_Core_Helper_Abstract
             }
             //Subscription for One Step Checkout with force subscription
         } elseif (Mage::getSingleton('core/session')->getIsOneStepCheckout() && Mage::helper('monkey')->config('checkout_subscribe') > 2 && !Mage::getSingleton('core/session')->getIsUpdateCustomer()) {
-            $this->subscribeToList($object, $db);
+            $this->subscribeToList($object, $db, null, true);
         } elseif(!$post){
             //subscribe customer from admin
             $this->subscribeToList($object, $db, TRUE);


### PR DESCRIPTION
This makes sure that the user does not get a confirmation mail if he was forced to subscribe and did not explicitely checked the subscribe box (in the OneStepCheckout).