### PR TITLE
Specific Default Groups (list groups)

### DIFF
--- a/app/code/community/Ebizmarts/MageMonkey/etc/system.xml
+++ b/app/code/community/Ebizmarts/MageMonkey/etc/system.xml
@@ -137,11 +137,21 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>1</show_in_store>
                         </changecustomergroup>
+                        <default_customergroup translate="label comment">
+                            <label>Default Subscriber Group</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>monkey/system_config_source_customerGroup</source_model>
+                            <sort_order>35</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <can_be_empty>1</can_be_empty>
+                        </default_customergroup>
                         <showreallistname translate="label comment">
                             <label>Show Original List Name</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>35</sort_order>
+                            <sort_order>36</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Allow specific groups to be automatically signed up when a customer signs up (per store).  Additionally allows one to add lists to the default to facilitate forms that sign up to the defaults + some extra list(s).

This re-uses the current 'monkey/system_config_source_customerGroup' config model to allow the selection.

This has been in use for a long time through several versions of MageMonkey in a production environment with lots of 'advanced' use cases.  We have iPad fixtures setup that RPC subscribe and 'mixin' their unique location lists.  We also have a variety of forms that all do basically the same thing.