### PR TITLE
Allow mandrill to use magento queue

### DIFF
--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
@@ -1,0 +1,93 @@
+<?php
+
+class Ebizmarts_Mandrill_Model_Email_Queue extends Mage_Core_Model_Email_Queue
+{
+    /**
+     * Send all messages in a queue via manrill
+     *
+     * @return Mage_Core_Model_Email_Queue
+     */
+    public function send()
+    {
+
+        if (!Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::ENABLE, $storeId)) {
+            return parent::send();
+        }
+
+        /** @var $collection Mage_Core_Model_Resource_Email_Queue_Collection */
+        $collection = Mage::getModel('core/email_queue')->getCollection()
+            ->addOnlyForSendingFilter()
+            ->setPageSize(self::MESSAGES_LIMIT_PER_CRON_RUN)
+            ->setCurPage(1)
+            ->load();
+
+        /** @var $message Mage_Core_Model_Email_Queue */
+        foreach ($collection as $message) {
+            if ($message->getId()) {
+                $parameters = new Varien_Object($message->getMessageParameters());
+
+                $mailer = $this->getMail();
+
+                $mandrill = [
+                    'subject' => $parameters->getSubject(),
+                    'to' => [],
+                    'from_email' => $parameters->getFromEmail(),
+                    'from_name' => $parameters->getFromName(),
+                    'headers' => $mailer->getHeaders(),
+                    'html' => ($parameters->getIsPlain() ? "" : $message->getMessageBody()),
+                    'text' => ($parameters->getIsPlain() ? $message->getMessageBody() : ""),
+                ];
+
+                foreach ($message->getRecipients() as $recipient) {
+                    list($email, $name, $type) = $recipient;
+
+                    $mandrill['to'][] = [
+                        'type' => ($type == self::EMAIL_TYPE_BCC ? "bcc" : "to"),
+                        'email' => $email,
+                        'name' => $name
+                    ];
+                }
+
+                if ($parameters->getReplyTo() !== null) {
+                    $mandrill['headers'] = array_merge($mandril['headers'], ['Reply-To' => $parameters->getReplyTo()]);
+                }
+
+                if ($parameters->getReturnTo() !== null) {
+                    $mailer->setReturnPath($parameters->getReturnTo());
+                }
+
+                try {
+                    $mailer->messages->send($mandrill);
+                } catch (Exception $e) {
+                    Mage::logException($e);
+                }
+
+                unset($mailer);
+                unset($mandrill);
+                $message->setProcessedAt(Varien_Date::formatDate(true));
+                $message->save();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Mandrill_Message|Zend_Mail
+     */
+    public function getMail()
+    {
+        $storeId = Mage::app()->getStore()->getId();
+        if (!Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::ENABLE, $storeId)) {
+            return parent::getMail();
+        }
+        if ($this->_mail) {
+            return $this->_mail;
+        } else {
+            $storeId = Mage::app()->getStore()->getId();
+            Mage::helper('ebizmarts_mandrill')->log("store: $storeId API: " . Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::APIKEY, $storeId));
+            $this->_mail = new Mandrill_Message(Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::APIKEY, $storeId));
+            return $this->_mail;
+        }
+    }
+}

--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
@@ -9,7 +9,7 @@ class Ebizmarts_Mandrill_Model_Email_Queue extends Mage_Core_Model_Email_Queue
      */
     public function send()
     {
-
+        $storeId = Mage::app()->getStore()->getId();
         if (!Mage::getStoreConfig(Ebizmarts_Mandrill_Model_System_Config::ENABLE, $storeId)) {
             return parent::send();
         }

--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
@@ -97,6 +97,19 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
             }
         }
 
+        $setReturnPath = Mage::getStoreConfig(self::XML_PATH_SENDING_SET_RETURN_PATH);
+        switch ($setReturnPath) {
+            case 1:
+                $returnPathEmail = $this->getSenderEmail();
+                break;
+            case 2:
+                $returnPathEmail = Mage::getStoreConfig(self::XML_PATH_SENDING_RETURN_PATH_EMAIL);
+                break;
+            default:
+                $returnPathEmail = null;
+                break;
+        }
+
         if ($att = $mail->getAttachments()) {
             $email['attachments'] = $att;
         }

--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
@@ -42,8 +42,9 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
         $variables['email'] = reset($emails);
         $variables['name'] = reset($names);
         $message = $this->getProcessedTemplate($variables, true);
+        $subject = $this->getProcessedTemplateSubject($variables);
 
-        $email = array('subject' => $this->getProcessedTemplateSubject($variables), 'to' => array());
+        $email = array('subject' => $subject, 'to' => array());
 
         $mail = $this->getMail();
         $max = count($emails);
@@ -103,6 +104,24 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
             $email['text'] = $message;
         else
             $email['html'] = $message;
+
+        if ($this->hasQueue() && $this->getQueue() instanceof Mage_Core_Model_Email_Queue) {
+
+            $emailQueue = $this->getQueue();
+            $emailQueue->setMessageBody($message);
+            $emailQueue->setMessageParameters(array(
+                    'subject'           => $subject,
+                    'return_path_email' => $returnPathEmail,
+                    'is_plain'          => $this->isPlain(),
+                    'from_email'        => $this->getSenderEmail(),
+                    'from_name'         => $this->getSenderName()
+                ))
+                ->addRecipients($emails, $names, Mage_Core_Model_Email_Queue::EMAIL_TYPE_TO)
+                ->addRecipients($this->_bccEmails, array(), Mage_Core_Model_Email_Queue::EMAIL_TYPE_BCC);
+            $emailQueue->addMessageToQueue();
+
+            return true;
+        }
 
         try {
             $result = $mail->messages->send($email);

--- a/app/code/community/Ebizmarts/Mandrill/etc/config.xml
+++ b/app/code/community/Ebizmarts/Mandrill/etc/config.xml
@@ -17,6 +17,7 @@
             <core>
                 <rewrite>
                     <email_template>Ebizmarts_Mandrill_Model_Email_Template</email_template>
+                    <email_queue>Ebizmarts_Mandrill_Model_Email_Queue</email_queue>
                 </rewrite>
             </core>
         </models>


### PR DESCRIPTION
Since mage 1.9 magento uses a cron task `core_email_queue_send_all` to send emails. This PR adds the ability for mandrill to send from the queue instead of sending now. Tested and working on `EE 1.14.2.2`

Open for comments and changes.