### PR TITLE
`CURLOPT_FOLLOWLOCATION` breaking with `open_basedir`

### DIFF
--- a/lib/Mandrill/Mandrill.php
+++ b/lib/Mandrill/Mandrill.php
@@ -86,7 +86,9 @@ class Mandrill_Mandrill
         $this->ch = curl_init();
         curl_setopt($this->ch, CURLOPT_USERAGENT, 'Mandrill-PHP/1.0.53');
         curl_setopt($this->ch, CURLOPT_POST, true);
-        curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
+        if (!ini_get('open_basedir')) {
+            curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
+        }
         curl_setopt($this->ch, CURLOPT_HEADER, false);
         curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, 30);


### PR DESCRIPTION
When `open_basedir` is enabled on the server, `CURLOPT_FOLLOWLOCATION` does not work. As such, I added this flag to add it in scenarios where `open_basedir` is not enabled, only.