### PR TITLE
Update Cron.php

### DIFF
--- a/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
+++ b/app/code/community/Ebizmarts/AbandonedCart/Model/Cron.php
@@ -211,7 +211,7 @@ class Ebizmarts_AbandonedCart_Model_Cron
 
                 //if hour is set for first run calculates hours since cart was created else calculates days
                 $today = idate('U', strtotime(now()));
-                $updatedAt = idate('U', strtotime($quote2->getUpdatedAt()));
+                $updatedAt = idate('U', strtotime($quote->getUpdatedAt()));
                 $updatedAtDiff = ($today - $updatedAt) / 60 / 60 / 24;
                 if ($this->unit == Ebizmarts_AbandonedCart_Model_Config::IN_HOURS && $run == 0) {
                     $updatedAtDiff = ($today - $updatedAt) / 60 / 60;


### PR DESCRIPTION
The Magento method loadByIdWithoutStore will change the updated_at time of the quote if "trigger_recollect" is set to "true". (Magento triggers a recollect on all quotes in the database whenever you modify a promotional rule.) This can cause emails to get delayed well beyond the configured time.

We have modified our local install of Abandoned Cart to use the original $quote updated_at time vs. the $quote2.