### PR TITLE
Mandrill was unable to verify sender's domain

### DIFF
--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Template.php
@@ -82,10 +82,12 @@ class Ebizmarts_Mandrill_Model_Email_Template extends Mage_Core_Model_Email_Temp
 
         $email['from_name'] = $this->getSenderName();
         $email['from_email'] = $this->getSenderEmail();
+        $domainPos = strrpos($email['from_email'], '@');
+        $senderDomain = substr($email['from_email'], $domainPos + 1);
         $mandrillSenders = $mail->senders->domains();
         $senderExists = false;
         foreach ($mandrillSenders as $sender) {
-            if($email['from_email'] == $sender['domain']) {
+            if($senderDomain == $sender['domain']) {
                 $senderExists = true;
             }
         }


### PR DESCRIPTION
When sending an email using Mandrill and Magento template system, the module tries to compare a full email address (`$email['from_email']`) with Mandrill's approved senders domains (`$mail->senders->domains()`), which always fails and always fallback to default Magento sender address.

This commit fixes the problem.