### PR TITLE
Add conflicts with aschroder/smtp_pro magento module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
             "email": "info@ebizmarts.com"
         }
     ],
+    "conflict": {
+        "aschroder/smtp_pro": "*"
+    }
     "require": {
         "magento-hackathon/magento-composer-installer": "*"
     }


### PR DESCRIPTION
We used aschroder/smtp_pro magento module. After installing this Magemonkey (which contains Mandrill) - email stopped getting send even if Enable mandrill option was set to "No". 

It was caused by rewrite conflict between these modules.

In order to prevent such issues for other people - let's add this conflict to composer.

aschroder/smtp_pro module located there: https://github.com/aschroder/Magento-SMTP-Pro-Email-Extension