### PR TITLE
notify back to stock shows when manage stock is inactive

### DIFF
--- a/app/design/frontend/base/default/template/ebizmarts/autoresponder/backtostock/catalog/product/notice.phtml
+++ b/app/design/frontend/base/default/template/ebizmarts/autoresponder/backtostock/catalog/product/notice.phtml
@@ -13,7 +13,7 @@
 $_product = $this->getProduct();
 $formAction = $this->getSubscribeUrl();
 ?>
-<?php if ($_product && (!$_product->getStockItem()->getIsInStock() || $_product->getStockItem()->getQty() == 0 && $_product->getTypeId() == "simple") && Mage::helper('ebizmarts_autoresponder')->config('backtostock/active')): ?>
+<?php if ($_product && $_product->getStockItem()->getManageStock() && (!$_product->getStockItem()->getIsInStock() || $_product->getStockItem()->getQty() == 0 && $_product->getTypeId() == "simple") && Mage::helper('ebizmarts_autoresponder')->config('backtostock/active')): ?>
 
     <?php if ($this->isLoggedIn() || (!$this->isLoggedIn() && Mage::helper('ebizmarts_autoresponder')->isBacktoStockEnabledForGuest())): ?>
         <div class="box-collateral block-autoresponder-backtostock">


### PR DESCRIPTION
"Sign up to be notified when this product is back to stock" link shows on products which are saleable.
It doesn't take into account that stock quantity can be low and the product still is available when stock isn't managed for this product.