### PR TITLE
if not an order email, send using core send function

### DIFF
--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
@@ -78,6 +78,8 @@ class Ebizmarts_Mandrill_Model_Email_Queue extends Mage_Core_Model_Email_Queue
                     } else {
                         $this->_sendWithoutMandrill($message);
                     }
+                } else {
+                    parent::send();
                 }
             }
         }


### PR DESCRIPTION
Situation
A third party extension is adding non-order emails to the core_email_queue. We now have around 150 emails queued and ready to send in this table, with some order emails at the end.

Problem
When Ebizmarts_Mandrill_Model_Email_Queue is ran on the cron it is loading in the first 100 emails and processing them, on line 33 the script checks if $message->getEntityId == 'order' with no else statement to capture non-order emails. Non of these 100 emails in the queue have that entity_id so they are all skipped. The next time the cron runs it loads the same 100 emails (because they haven't been processed) and proceeds to skip them all again. The loop continues.

Solution
Added an else to capture and send non-order emails using Mage_Core_Model_Email_Queue default send() function. 