### PR TITLE
Allow to send any other emails from the queue

### DIFF
--- a/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
+++ b/app/code/community/Ebizmarts/Mandrill/Model/Email/Queue.php
@@ -78,10 +78,13 @@ class Ebizmarts_Mandrill_Model_Email_Queue extends Mage_Core_Model_Email_Queue
                     } else {
                         $this->_sendWithoutMandrill($message);
                     }
+                    
+                    return $this;
                 }
             }
         }
-        return $this;
+        
+        return parent::send();
     }
 
     /**


### PR DESCRIPTION
I don't understand why you blocking all other emails (not only orders) from the queue.